### PR TITLE
Enhance CI/CD Workflows with Docker Build Support

### DIFF
--- a/.github/workflows/continuousdelivery.yml
+++ b/.github/workflows/continuousdelivery.yml
@@ -29,3 +29,30 @@ jobs:
           name: zip-project.zip
       - name: Display structure of downloaded files
         run: ls -R
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ vars.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: user/app:latest

--- a/.github/workflows/continuousintegration.yml
+++ b/.github/workflows/continuousintegration.yml
@@ -28,3 +28,23 @@ jobs:
 
       - name: Run tests
         run: pytest test_main.py
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@
+      - # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: user/app:latest


### PR DESCRIPTION
## **Enhance CI/CD Workflows with Docker Build Support**

### **Description**  
This PR adds Docker build steps to both the Continuous Integration and Continuous Delivery workflows. It prepares the project for container-based deployment in the future.

---

### **Changes**
- ✅ Added a new `docker` job in both workflows.
- 🐳 Set up QEMU and Docker Buildx.
- 🔨 Built Docker image with `docker/build-push-action@v6`.
- 🚫 Docker push is disabled for now (`push: false`).

---

### **Why**  
To ensure our app builds correctly inside a Docker container and to prepare for future deployments using Docker.

---

### **Note**  
Login to Docker Hub is included but commented out.
